### PR TITLE
declare proper dir for git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ various plugin managers are given bellow.
 Issue following commands.
 
 ```sh
-git clone https://github.com/Shougo/vimproc.vim.git ~/.vim/bundle
+git clone https://github.com/Shougo/vimproc.vim.git ~/.vim/bundle/vimproc.vim
 cd ~/.vim/bundle/vimproc.vim
 make
 cd ..


### PR DESCRIPTION
Avoids `fatal: destination path '/home/pmoust/.vim/bundle' already exists and is not an empty directory.` and clones in proper path
