### PR TITLE
Fix PHP Error Notice if `@return []` found

### DIFF
--- a/bin/IndexGenerator.php
+++ b/bin/IndexGenerator.php
@@ -909,7 +909,7 @@ class IndexGenerator
                     $arrayReturn = 1;
                     $rType = trim($rType, "[]");
                 }
-                if(!$this->isScalar($rType)) {
+                if(!empty($rType) && !$this->isScalar($rType)) {
                     $returnType = $rType;
                     if($returnType[0] == '\\') {
                         $returnType = substr($returnType, 1);


### PR DESCRIPTION
- While PHPCompleteExtendedGenerateIndex is running, if encounters a
  method with `@return []` in the docblock it will issue a error:
  "PHP Notice: Uninitialized string offset: 0 in
  .vim/bundle/phpcomplete-extended/bin/IndexGenerator.php
  on line 914" because '[' and ']' are trim'ed off on a previous line.
