### PR TITLE
[Documentation update] use Plugin instead Bundle for Vundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ compile the library.
 
 ## Vundle
 
-Put following lines in `.vimrc` and issue `:BundleInstall` command.
+Put following lines in `.vimrc` and issue `:PluginInstall` command.
 ```vim
-Bundle 'Shougo/vimproc'
-Bundle 'Shougo/unite.vim'
-Bundle 'm2mdas/phpcomplete-extended'
+Plugin 'Shougo/vimproc'
+Plugin 'Shougo/unite.vim'
+Plugin 'm2mdas/phpcomplete-extended'
 "your other plugins
 "....
 ```

--- a/doc/phpcomplete-extended.txt
+++ b/doc/phpcomplete-extended.txt
@@ -102,11 +102,11 @@ compile the library.
 
 ## Vundle
 
-Put following lines in `.vimrc` and issue `:BundleInstall` command.
+Put following lines in `.vimrc` and issue `:PluginInstall` command.
 ```vim
-Bundle 'Shougo/vimproc'
-Bundle 'Shougo/unite.vim'
-Bundle 'm2mdas/phpcomplete-extended'
+Plugin 'Shougo/vimproc'
+Plugin 'Shougo/unite.vim'
+Plugin 'm2mdas/phpcomplete-extended'
 "your other plugins
 "....
 ```


### PR DESCRIPTION
Vundle makes an effort to unify the use of their plug-in manager.

The commit on Vundle :
https://github.com/gmarik/Vundle.vim/commit/0521de95eac09298c4e71b3662839612280c1ae9

Some Vim plugins started to change the syntax. Let's follow the movement :)
