### PR TITLE
Changed the matching for the composer version

### DIFF
--- a/autoload/phpcomplete_extended.vim
+++ b/autoload/phpcomplete_extended.vim
@@ -1456,7 +1456,7 @@ endfunction "}}}
 function! s:valid_composer_command() "{{{
     let cmd    = printf('%s --version', g:phpcomplete_index_composer_command)
     let output = system(cmd)
-    return output =~ 'Composer version'
+    return output =~ '^Composer [1-9\.]\+'
 endfunction "}}}
 
 function! phpcomplete_extended#updateIndex(background) "{{{


### PR DESCRIPTION
The way composer displays its version has changed, so changed the matching to support this change in version display.

Closes: #58